### PR TITLE
Object to BaseObject

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["yii", "yii2", "authentication", "CAS"],
     "require": {
         "php": ">=5.4.0",
-        "yiisoft/yii2": "~2.0.0",
+        "yiisoft/yii2": "~2.0.13",
         "jasig/phpcas": "^1.3"
     },
     "autoload": {

--- a/src/CasService.php
+++ b/src/CasService.php
@@ -15,7 +15,7 @@ use yii\helpers\Url;
  *
  * @author François Gannaz <francois.gannaz@silecs.info>
  */
-class CasService extends \yii\base\Object
+class CasService extends \yii\base\BaseObject
 {
     const LOGPATH = '@runtime/logs/cas.log';
 


### PR DESCRIPTION
to support php7.2 and above must used BaseObject because Object is a reserved word in php 7.2 and above